### PR TITLE
Documentation fixes; added missing category migration

### DIFF
--- a/docs/relationships/index.rst
+++ b/docs/relationships/index.rst
@@ -15,7 +15,7 @@ First, add the module to ``settings.INSTALLED_APPS``::
 
     INSTALLED_APPS = (
         ...
-        'wagtailplus.wagtailrelationships',
+        'wagtailplus.wagtailrelations',
         ...
     )
 

--- a/docs/relationships/index.rst
+++ b/docs/relationships/index.rst
@@ -19,6 +19,7 @@ First, add the module to ``settings.INSTALLED_APPS``::
         ...
     )
 
+If ``treebeard`` isn't already in your ``INSTALLED_APPS``, you'll need to add that as well.
 Then run ``manage.py syncdb`` (Django < 1.7) or ``manage.py migrate`` (Django >= 1.7).
 
 Settings

--- a/wagtailplus/wagtailrelations/migrations/0002_auto_20151027_2150.py
+++ b/wagtailplus/wagtailrelations/migrations/0002_auto_20151027_2150.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailrelations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='category',
+            options={'ordering': ('path',), 'verbose_name': 'Category', 'verbose_name_plural': 'Categories'},
+        ),
+    ]


### PR DESCRIPTION
Might be worth considering either renaming the `relations` app to 'relationships' or the docs to 'relations' to avoid confusion as well.