### PR TITLE
Fix display of related pages with non-ASCII titles

### DIFF
--- a/wagtailplus/wagtailrelations/templates/wagtailrelations/edit_handlers/related.html
+++ b/wagtailplus/wagtailrelations/templates/wagtailrelations/edit_handlers/related.html
@@ -14,7 +14,7 @@
             <tbody>
                 {% for content in self.instance.related_with_scores|slice:":20" %}
                     <tr>
-                        <td>{% blocktrans with title_str=content.0 %}{{ title_str }}{% endblocktrans %}</td>
+                        <td>{% blocktrans with title_str=content.0.title %}{{ title_str }}{% endblocktrans %}</td>
                         <td style="text-align: right;">{{ content.1|floatformat:"7" }}</td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
By calling blocktrans on the title rather than the entry object, we avoid UnicodeDecodeErrors on template rendering.