### PR TITLE
Bugfix - move entry URL from database to property

### DIFF
--- a/wagtailplus/wagtailrelations/migrations/0002_auto_20151123_1203.py
+++ b/wagtailplus/wagtailrelations/migrations/0002_auto_20151123_1203.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailrelations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='category',
+            options={'ordering': ('path',), 'verbose_name': 'Category', 'verbose_name_plural': 'Categories'},
+        ),
+        migrations.RemoveField(
+            model_name='entry',
+            name='url',
+        ),
+    ]

--- a/wagtailplus/wagtailrelations/migrations/0002_auto_20151123_1203.py
+++ b/wagtailplus/wagtailrelations/migrations/0002_auto_20151123_1203.py
@@ -11,10 +11,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterModelOptions(
-            name='category',
-            options={'ordering': ('path',), 'verbose_name': 'Category', 'verbose_name_plural': 'Categories'},
-        ),
         migrations.RemoveField(
             model_name='entry',
             name='url',

--- a/wagtailplus/wagtailrelations/models.py
+++ b/wagtailplus/wagtailrelations/models.py
@@ -159,7 +159,6 @@ class Entry(models.Model):
     created         = models.DateTimeField(_(u'Created'))
     modified        = models.DateTimeField(_(u'Modified'))
     title           = models.CharField(_(u'Title'), max_length=255, blank=True)
-    url             = models.CharField(_(u'URL'), max_length=255, blank=True)
     live            = models.BooleanField(_(u'Live?'), default=True)
     objects         = EntryManager()
 
@@ -167,6 +166,12 @@ class Entry(models.Model):
         verbose_name        = _(u'Entry')
         verbose_name_plural = _(u'Entries')
         ordering            = ('title',)
+
+    @cached_property
+    def url(self):
+        """Returns the URL of the linked object"""
+        default_url = getattr(self.content_object, 'get_absolute_url', '')
+        return getattr(self.content_object, 'url', default_url)
 
     @cached_property
     def related(self):

--- a/wagtailplus/wagtailrelations/signals/handlers.py
+++ b/wagtailplus/wagtailrelations/signals/handlers.py
@@ -71,9 +71,7 @@ def update_entry_attributes(sender, instance, **kwargs):
 
     entry = Entry.objects.get_for_model(instance)[0]
 
-    default_url = getattr(instance, 'get_absolute_url', '')
     entry.title = getattr(instance, 'title', str(instance))
-    entry.url   = getattr(instance, 'url', default_url)
     entry.live  = bool(getattr(instance, 'live', True))
 
     entry.save()


### PR DESCRIPTION
Storing the URLs in the database causes errors on save for pages with
long titles (close to 255 characters) because the generated URLs would
end up being longer than 255 characters when combined with path
information. Moving the URL attribute to a property bypassess this issue                                                                                                                                                                                                                                                                                                    by not attempting to put it in the database. We could also address this                                                                                                                                                                                                                                                                                                     by increasing the max_length of the URL field but there doesn't seem to
be any reason for storing this information on the Entry other than for 
convenience, so the property should suffice.