### PR TITLE
Link to edit URL of pages listed as 'related'

### DIFF
--- a/wagtailplus/wagtailrelations/templates/wagtailrelations/edit_handlers/related.html
+++ b/wagtailplus/wagtailrelations/templates/wagtailrelations/edit_handlers/related.html
@@ -14,7 +14,10 @@
             <tbody>
                 {% for content in self.instance.related_with_scores|slice:":20" %}
                     <tr>
-                        <td>{% blocktrans with title_str=content.0 %}{{ title_str }}{% endblocktrans %}</td>
+                        <td>
+                            <a href="{% url wagtailadmin_pages:edit content.0.object_id %}"
+                                >{% blocktrans with title_str=content.0 %}{{ title_str }}{% endblocktrans %}</a>
+                        </td>
                         <td style="text-align: right;">{{ content.1|floatformat:"7" }}</td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
It might be worth going further and, e.g. linking to the 'live' page,
showing more 'path' information about where that page is, etc, but for
now, at least you get to the edit page and so can figure everything else
out from there.