### PR TITLE
Fix UnicodeDecodeErrors with unicode emails & category names

### DIFF
--- a/wagtailplus/wagtaillinks/tests/test_models.py
+++ b/wagtailplus/wagtaillinks/tests/test_models.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Contains model unit tests.
 """
+from __future__ import unicode_literals
 from django.test import TestCase
 
 from wagtail.wagtailadmin.edit_handlers import ObjectList
@@ -23,7 +26,7 @@ class TestEmailLink(TestCase):
         self.model = Link.objects.create(
             link_type   = Link.LINK_TYPE_EMAIL,
             title       = 'Test Email Address',
-            email       = 'somebody@something.com'
+            email       = 'somébody@something.com'
         )
 
     def test_url_property(self):
@@ -39,6 +42,12 @@ class TestEmailLink(TestCase):
         self.assertTrue(
             self.model in EmailLink.objects.all()
         )
+
+    def test_unicode_email_addres(self):
+        try:
+            str(self.model)
+        except UnicodeDecodeError:
+            raise AssertionError("Failed to `str` the unicode email address")
 
 class TestExternalLink(TestCase):
     def setUp(self):

--- a/wagtailplus/wagtailrelations/models.py
+++ b/wagtailplus/wagtailrelations/models.py
@@ -1,6 +1,8 @@
 """
 Contains application model definitions.
 """
+from __future__ import unicode_literals
+
 import decimal
 import inspect
 import six

--- a/wagtailplus/wagtailrelations/tests/test_models.py
+++ b/wagtailplus/wagtailrelations/tests/test_models.py
@@ -1,6 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Contains model unit tests.
 """
+from __future__ import unicode_literals
+
 import decimal
 
 from django.test import TestCase
@@ -21,6 +25,7 @@ class TestCategory(TestCase):
         # Create some categories.
         self.category       = Category.add_root(name='category')
         self.sub_category   = self.category.add_child(name='sub category')
+        self.unicode_sub    = self.category.add_child(name='sub catégory')
 
         # Get the root page.
         self.root_page = Page.objects.get(id=2)
@@ -65,6 +70,13 @@ class TestCategory(TestCase):
     def test_set_tag(self):
         self.sub_category.set_tag()
         self.assertEqual(type(self.sub_category.tag), Tag)
+
+    def test_unicode_category_name(self):
+        try:
+            str(self.unicode_sub)
+        except UnicodeDecodeError:
+            raise AssertionError("Failed to `str` the unicode category name")
+
 
 class TestEntity(TestCase):
     def setUp(self):


### PR DESCRIPTION
Added tests (all tests now pass in all defined tox environments). The tests won't actually run until https://github.com/rfosterslo/wagtailplus/pull/10 is merged. There are several files that still don't have the `unicode_literals` import in them, but I'd suggest addressing those as required rather than adding across the board.