### PR TITLE
Move edit_handlers imports to within the add method

### DIFF
--- a/wagtailplus/wagtailrollbacks/apps.py
+++ b/wagtailplus/wagtailrollbacks/apps.py
@@ -8,10 +8,6 @@ from django.contrib.admin.apps import SimpleAdminConfig
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from wagtailplus.utils.edit_handlers import add_panel_to_edit_handler
-
-from wagtailplus.wagtailrollbacks.edit_handlers import HistoryPanel
-
 
 logger = logging.getLogger('wagtail.core')
 
@@ -39,7 +35,10 @@ class WagtailRollbacksAppConfig(SimpleAdminConfig):
     def add_rollback_panels(self):
         """
         Adds rollback panel to applicable model class's edit handlers.
+        Imports below to avoid model imports before django.setup() for Django 1.9 compat
         """
+        from wagtailplus.utils.edit_handlers import add_panel_to_edit_handler
+        from wagtailplus.wagtailrollbacks.edit_handlers import HistoryPanel
         for model in self.applicable_models:
             add_panel_to_edit_handler(model, HistoryPanel, _(u'History'))
 


### PR DESCRIPTION
This allows wagtailadmin to only start pulling in models and contenttypes after Django 1.9 initialisation, avoiding apps not loaded exception